### PR TITLE
Added Qwen3 Embeddings 0.6B and 4B. Added embeddings description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eines d'avaluació de models LLM i ASR
+# Eines d'avaluació de models LLM, ASR i Embeddings
 
 Aquest repositori conté eines per avaluar les capacitats de models de llenguatge gran (LLM) i de reconeixement automàtic de la parla (ASR), amb focus especial en la llengua catalana.
 Els resultats estan compartits a https://www.softcatala.org/ia-local/models-en-catala/
@@ -74,7 +74,7 @@ El pipeline `llm/model.py` avalua models GGUF (via `llama-server`) i models de l
 | **VeritasQA** | Preguntes obertes en català | Accuracy |
 | **STS-ca** | Similitud semàntica de frases | Correlació de Pearson |
 | **CatCoLA** | Acceptabilitat gramatical | MCC |
-| **CLUB / VilaQuAD** | Comprensió lectora i QA | Exact Match |
+| **CLUB / VilaQuAD** | Comprensió lectora (QA) | Exact Match |
 | **CaSum** | Resum de notícies en català | ROUGE-1/2/L |
 | **IberBench** | Múltiples tasques NLP (via lm-eval) | Diverses |
 | **FLORES+** | Traducció automàtica EN↔CA | BLEU |
@@ -97,10 +97,11 @@ cd llm
 uv run python model.py --model "bartowski/Llama-3.2-3B-Instruct-GGUF:Q8_0" --device cuda
 ```
 
-**Avaluar amb l'API de Google AI (Gemma/Gemini):**
+**Avaluar amb l'API de Google AI o OpenAI:**
 
 ```bash
-uv run python model.py --model gemini --api-key "LA_TEVA_CLAU" --gemini-model gemma-3-27b-it
+uv run python model.py --model gemini --api-key "LA_TEVA_CLAU" --gemini-model gemini-3.5-flash
+uv run python model.py --model openai --api-key "LA_TEVA_CLAU" --openai-model gpt-4o
 ```
 
 **Avaluar benchmarks específics:**
@@ -109,7 +110,7 @@ uv run python model.py --model gemini --api-key "LA_TEVA_CLAU" --gemini-model ge
 uv run python model.py --model "bartowski/Llama-3.2-3B-Instruct-GGUF:Q8_0" --benchmarks catcola flores
 ```
 
-**Executar tots els models de la llista (orquestrador):**
+**Executar l'orquestrador per a múltiples models:**
 
 ```bash
 uv run python run_evals.py
@@ -155,6 +156,50 @@ uv run python hf-eval.py --list-models
 uv run python hf-eval.py whisper-large-v3 --device cuda --num_samples 500
 uv run python hf-eval.py whisper-small omniASR_CTC_300M --output results.csv
 ```
+
+
+## Embeddings — Avaluació de models d'embeddings
+
+El pipeline `embeddings/model.py` avalua models de representació vectorial (Sentence Transformers o APIs de núvol) sobre benchmarks de català:
+
+| Benchmark | Tasca | Mètrica |
+|-----------|-------|---------|
+| **STS-ca** | Similitud semàntica de frases | Correlació de Spearman |
+| **XQuAD-ca** | Recuperació de context (Retrieval) | nDCG@10 |
+| **TeCla** | Classificació temàtica (Linear probe) | Macro F1 |
+
+### Instal·lació (Embeddings)
+
+Requereix [uv](https://docs.astral.sh/uv/).
+
+```bash
+cd embeddings
+uv sync
+```
+
+### Execució (Embeddings)
+
+**Avaluar un model de Hugging Face / Sentence Transformers:**
+
+```bash
+cd embeddings
+uv run python model.py --model "<nom_model>" --output evals/<nom_model>.json
+```
+
+**Avaluar amb l'API d'OpenAI o Google:**
+
+```bash
+uv run python model.py --cloud-provider openai --model text-embedding-3-large --output evals/results_openai_text_embedding_3_large.json
+uv run python model.py --cloud-provider google --model embedding-001 --output evals/results_google_gemini_embedding_001.json
+```
+
+**Executar l'orquestrador per a múltiples models:**
+
+```bash
+uv run python run_evals.py
+```
+
+Els resultats es desen com a JSON a `embeddings/evals/`.
 
 ---
 

--- a/embeddings/evals/results_qwen3_embedding_06b.json
+++ b/embeddings/evals/results_qwen3_embedding_06b.json
@@ -1,0 +1,31 @@
+{
+  "model": "Qwen/Qwen3-Embedding-0.6B",
+  "display_name": "Qwen3-Embedding-0.6B",
+  "cloud": false,
+  "embedding_dim": 1024,
+  "benchmarks": {
+    "xquad_ca_retrieval": {
+      "ndcg_at_10": 0.9186,
+      "ndcg_at_10_ci": [
+        0.9064,
+        0.9305
+      ],
+      "n_queries": 1189,
+      "n_corpus": 240
+    },
+    "sts_ca": {
+      "spearman": 0.648,
+      "spearman_ci": [
+        0.5945,
+        0.7015
+      ],
+      "n_pairs": 500
+    },
+    "tecla_classification": {
+      "macro_f1": 0.9186,
+      "n_train": 10000,
+      "n_test": 17007,
+      "n_classes": 4
+    }
+  }
+}

--- a/embeddings/evals/results_qwen3_embedding_4b.json
+++ b/embeddings/evals/results_qwen3_embedding_4b.json
@@ -1,0 +1,31 @@
+{
+  "model": "Qwen/Qwen3-Embedding-4B",
+  "display_name": "Qwen3-Embedding-4B",
+  "cloud": false,
+  "embedding_dim": 2560,
+  "benchmarks": {
+    "xquad_ca_retrieval": {
+      "ndcg_at_10": 0.9596,
+      "ndcg_at_10_ci": [
+        0.9509,
+        0.9674
+      ],
+      "n_queries": 1189,
+      "n_corpus": 240
+    },
+    "sts_ca": {
+      "spearman": 0.6552,
+      "spearman_ci": [
+        0.6016,
+        0.7089
+      ],
+      "n_pairs": 500
+    },
+    "tecla_classification": {
+      "macro_f1": 0.9308,
+      "n_train": 10000,
+      "n_test": 17007,
+      "n_classes": 4
+    }
+  }
+}

--- a/embeddings/evals/results_qwen3_embedding_8b.json
+++ b/embeddings/evals/results_qwen3_embedding_8b.json
@@ -1,0 +1,31 @@
+{
+  "model": "Qwen/Qwen3-Embedding-8B",
+  "display_name": "Qwen3-Embedding-8B",
+  "cloud": false,
+  "embedding_dim": 4096,
+  "benchmarks": {
+    "xquad_ca_retrieval": {
+      "ndcg_at_10": 0.9621,
+      "ndcg_at_10_ci": [
+        0.9543,
+        0.9695
+      ],
+      "n_queries": 1189,
+      "n_corpus": 240
+    },
+    "sts_ca": {
+      "spearman": 0.6629,
+      "spearman_ci": [
+        0.61,
+        0.7144
+      ],
+      "n_pairs": 500
+    },
+    "tecla_classification": {
+      "macro_f1": 0.9339,
+      "n_train": 10000,
+      "n_test": 17007,
+      "n_classes": 4
+    }
+  }
+}

--- a/embeddings/pyproject.toml
+++ b/embeddings/pyproject.toml
@@ -8,11 +8,13 @@ dependencies = [
     "numpy",
     "scipy",
     "einops>=0.8.2",
-    "xformers>=0.0.35",
 ]
 
 [project.optional-dependencies]
 cloud = [
     "openai>=1.0.0",
     "google-genai>=0.3.0",
+]
+cuda = [
+    "xformers>=0.0.35; platform_system == 'Linux' and platform_machine == 'x86_64'",
 ]

--- a/embeddings/uv.lock
+++ b/embeddings/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -636,13 +636,15 @@ dependencies = [
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sentence-transformers" },
-    { name = "xformers" },
 ]
 
 [package.optional-dependencies]
 cloud = [
     { name = "google-genai" },
     { name = "openai" },
+]
+cuda = [
+    { name = "xformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [package.metadata]
@@ -654,9 +656,9 @@ requires-dist = [
     { name = "openai", marker = "extra == 'cloud'", specifier = ">=1.0.0" },
     { name = "scipy" },
     { name = "sentence-transformers", specifier = ">=3.0.0" },
-    { name = "xformers", specifier = ">=0.0.35" },
+    { name = "xformers", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'cuda'", specifier = ">=0.0.35" },
 ]
-provides-extras = ["cloud"]
+provides-extras = ["cloud", "cuda"]
 
 [[package]]
 name = "exceptiongroup"
@@ -3174,14 +3176,13 @@ version = "0.0.35"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "torch" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "numpy", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "torch", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/5a/6e27734bd793adc44d0b8d294e67cfacf4ec590572c1aef51d683fc7a791/xformers-0.0.35.tar.gz", hash = "sha256:f7fc183a58e4bf0e2ae339a18fb1b1d4a37854c0f2545b4f360fef001646ab76", size = 4258182, upload-time = "2026-02-20T20:33:05.417Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/85/6d71f9b16f2ac647877e66ed4af723b3fbd477806ab8b8a89d39a362b85f/xformers-0.0.35-py39-none-manylinux_2_28_x86_64.whl", hash = "sha256:ccc73c7db9890224ab05f5fb60e2034f9e6c8672a10be0cf00e95cbbae3eda7c", size = 3264751, upload-time = "2026-02-20T20:33:02.444Z" },
-    { url = "https://files.pythonhosted.org/packages/49/0b/88c39c128a05d5b553a67cb9c4c3fc32eefb91f836f838befab9e78f8364/xformers-0.0.35-py39-none-win_amd64.whl", hash = "sha256:57381ce3cbb79b593e6b62cb20a937885345fad2796de2aa6fbb66c033601179", size = 2638618, upload-time = "2026-02-20T20:33:04.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


- Runned Qwen3 Embeddings 0.6B, 4B and 8B.
- For Qwen3-Embedding-4B and 8B, I have used --max-seq-length 512. This can affect benchmark performance.
- Added Embedding description in README.md
- I have also changed pyproject.toml so I can run it on Mac.