### PR TITLE
Propagate inference request failures

### DIFF
--- a/llm/inference.py
+++ b/llm/inference.py
@@ -21,7 +21,7 @@ def call_with_retries(
     retries: int = 3,
     delay_seconds: float = 2.0,
 ) -> T:
-    """Run an inference request, retry transient failures, then re-raise."""
+    """Run an inference request, retry failures, then re-raise the final error."""
     for attempt in range(retries + 1):
         try:
             return operation()

--- a/llm/inference.py
+++ b/llm/inference.py
@@ -1,13 +1,45 @@
 """Shared inference parameters and small provider-specific conversions."""
 
+from collections.abc import Callable
 from pathlib import Path
+import time
+from typing import TypeVar
 
 import yaml
 
 
+T = TypeVar("T")
+
 INFERENCE_CONFIG = yaml.safe_load(
     Path(__file__).with_name("inference.yaml").read_text(encoding="utf-8")
 )
+
+
+def call_with_retries(
+    operation: Callable[[], T],
+    description: str,
+    retries: int = 3,
+    delay_seconds: float = 2.0,
+) -> T:
+    """Run an inference request, retry transient failures, then re-raise."""
+    for attempt in range(retries + 1):
+        try:
+            return operation()
+        except Exception as e:
+            if attempt >= retries:
+                print(
+                    f"[error] {description} failed after {attempt + 1} attempts: {e}",
+                    flush=True,
+                )
+                raise
+            print(
+                f"[warn] {description} failed "
+                f"(attempt {attempt + 1}/{retries + 1}), retrying: {e}",
+                flush=True,
+            )
+            time.sleep(delay_seconds)
+
+    raise RuntimeError("unreachable retry state")
 
 
 def inference_params(max_tokens=None, provider="llama", model_name=""):

--- a/llm/llamaserver.py
+++ b/llm/llamaserver.py
@@ -1,9 +1,8 @@
 import json
-import time
 import urllib.request
 from pathlib import Path
 
-from inference import chat_completion_params, inference_params
+from inference import call_with_retries, chat_completion_params, inference_params
 
 
 _MUSE_USER_TEMPLATE = Path(__file__).with_name("templates") / "muse_glimmer_user.jinja"
@@ -80,7 +79,7 @@ class LlamaServerModel:
         base_url: str,
         request_model: str | None = None,
         timeout: float = 120.0,
-        max_retries: int = 1,
+        max_retries: int = 3,
     ):
         self.model_spec = model_spec
         self.base_url = base_url.rstrip("/")
@@ -95,17 +94,15 @@ class LlamaServerModel:
             data=payload,
             headers={"Content-Type": "application/json"},
         )
-        last_error = None
-        for attempt in range(self.max_retries + 1):
-            try:
-                with urllib.request.urlopen(req, timeout=self.timeout) as resp:
-                    return json.loads(resp.read())
-            except Exception as e:
-                last_error = e
-                if attempt < self.max_retries:
-                    print(f"[warn] llama-server request failed, retrying: {e}", flush=True)
-                    time.sleep(1)
-        raise last_error
+        def _request():
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                return json.loads(resp.read())
+
+        return call_with_retries(
+            _request,
+            f"llama-server request to {path}",
+            retries=self.max_retries,
+        )
 
     def _completions(self, prompt: str, max_tokens: int, stop: list[str]) -> dict:
         params = inference_params(max_tokens)
@@ -154,11 +151,7 @@ class LlamaServerModel:
         return data["choices"][0]["text"].strip()
 
     def generate(self, prompt: str, max_new_tokens: int | None = None) -> str:
-        try:
-            if "muse-glimmer" in self.model_spec.lower():
-                return self._muse_completion(prompt, max_new_tokens)
-            data = self._chat_completions(prompt, max_tokens=max_new_tokens)
-            return data["choices"][0]["message"]["content"].strip()
-        except Exception as e:
-            print(f"[warn] llama-server generation failed: {e}", flush=True)
-            return ""
+        if "muse-glimmer" in self.model_spec.lower():
+            return self._muse_completion(prompt, max_new_tokens)
+        data = self._chat_completions(prompt, max_tokens=max_new_tokens)
+        return data["choices"][0]["message"]["content"].strip()

--- a/llm/model.py
+++ b/llm/model.py
@@ -39,7 +39,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from comet_config import COMET_CHECKPOINT, drop_legacy_translation_metrics
-from inference import chat_completion_params, lm_eval_params
+from inference import call_with_retries, chat_completion_params, lm_eval_params
 
 from llamaserver import (
     LlamaServerModel,
@@ -140,17 +140,15 @@ class GeminiModel:
 
     def generate(self, prompt: str, max_new_tokens: int | None = None) -> str:
         params = chat_completion_params(max_new_tokens, "gemini", self.model_name)
-        try:
-            response = self.client.chat.completions.create(
+        response = call_with_retries(
+            lambda: self.client.chat.completions.create(
                 model=self.model_name,
                 messages=[{"role": "user", "content": prompt}],
                 **params,
-            )
-            return (response.choices[0].message.content or "").strip()
-        except Exception as e:
-            print(f"[error] API call failed: {e}")
-            time.sleep(2)
-            return ""
+            ),
+            "Gemini API call",
+        )
+        return (response.choices[0].message.content or "").strip()
 
 
 
@@ -168,25 +166,23 @@ class OpenAIModel:
         self.total_cost: float | None = None  # None until first response with cost data
 
     def generate(self, prompt: str, max_new_tokens: int | None = None) -> str:
-        try:
-            params = chat_completion_params(max_new_tokens, self.provider, self.model_name)
-            response = self.client.chat.completions.create(
+        params = chat_completion_params(max_new_tokens, self.provider, self.model_name)
+        response = call_with_retries(
+            lambda: self.client.chat.completions.create(
                 model=self.model_name,
                 messages=[{"role": "user", "content": prompt}],
                 **params,
-            )
-            if response.usage:
-                self.prompt_tokens += response.usage.prompt_tokens
-                self.completion_tokens += response.usage.completion_tokens
-                # OpenRouter returns cost directly in usage
-                call_cost = getattr(response.usage, "cost", None)
-                if call_cost is not None:
-                    self.total_cost = (self.total_cost or 0.0) + call_cost
-            return (response.choices[0].message.content or "").strip()
-        except Exception as e:
-            print(f"[error] API call failed: {e}")
-            time.sleep(2)
-            return ""
+            ),
+            f"{self.provider} API call",
+        )
+        if response.usage:
+            self.prompt_tokens += response.usage.prompt_tokens
+            self.completion_tokens += response.usage.completion_tokens
+            # OpenRouter returns cost directly in usage
+            call_cost = getattr(response.usage, "cost", None)
+            if call_cost is not None:
+                self.total_cost = (self.total_cost or 0.0) + call_cost
+        return (response.choices[0].message.content or "").strip()
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Centralizes inference retry handling and lets API/server failures surface after retries instead of silently returning empty outputs.