### PR TITLE
Use mismatched COMET baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ El contracte de `llm/llms.json` publica aquestes mitjanes com `flores_en_ca` i
 `flores_ca2es` per a diagnòstic, però aquestes quatre columnes direccionals no es
 mostren a les taules ni als gràfics per defecte.
 
-Per calcular un baseline de COMET sense executar un traductor, el script usa la
-còpia de la font com a hipòtesi (`mt = src`) sobre FLORES devtest. Avalua les
-quatre direccions i, per defecte, usa 400 exemples per direcció:
+Per calcular un baseline de COMET sense executar un traductor, el script usa una
+traducció desaparellada com a hipòtesi (`mt = next ref`) sobre FLORES devtest.
+Avalua les quatre direccions i, per defecte, usa 400 exemples per direcció:
 
 ```bash
 cd llm
@@ -101,9 +101,7 @@ uv run python comet_baseline.py \
 
 Podeu canviar-ne la mida amb `--n-samples`.
 
-Amb el checkpoint `Unbabel/wmt22-comet-da` i 400 exemples de FLORES devtest per
-direcció, el baseline de còpia de font és: EN→CA 0.6809, CA→EN 0.7549, ES→CA
-0.8222 i CA→ES 0.8228.
+El JSON generat conté els valors de baseline per direcció.
 
 Cada fila dels JSON publicats inclou `repo_url`, calculat amb el helper compartit
 `eval_common.model_urls`.
@@ -330,4 +328,3 @@ Si feu servir aquestes eines o els resultats en un treball, citeu-ho així (i ci
   howpublished = {\url{https://github.com/Softcatala/ai-eval-catalan}}
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -89,19 +89,24 @@ El contracte de `llm/llms.json` publica aquestes mitjanes com `flores_en_ca` i
 `flores_ca2es` per a diagnòstic, però aquestes quatre columnes direccionals no es
 mostren a les taules ni als gràfics per defecte.
 
-Per calcular un baseline de COMET sense executar un traductor, el script usa una
-traducció desaparellada com a hipòtesi (`mt = next ref`) sobre FLORES devtest.
-Avalua les quatre direccions i, per defecte, usa 400 exemples per direcció:
+Per calcular un baseline de COMET sense executar un traductor, el script usa
+traduccions desaparellades com a hipòtesi sobre FLORES devtest. Les
+desaparella amb permutacions aleatòries de llavor fixa perquè FLORES està
+ordenat per document i una frase adjacent comparteix massa tema amb l'original.
+Avalua les quatre direccions i, per defecte, usa 400 exemples per direcció i la
+mitjana de 5 permutacions:
 
 ```bash
 cd llm
 uv run python comet_baseline.py \
-  --output evals/comet_source_copy_baseline.json
+  --output evals/comet_random_mismatch_baseline.json
 ```
 
-Podeu canviar-ne la mida amb `--n-samples`.
+Podeu canviar-ne la mida amb `--n-samples`, el nombre de permutacions amb
+`--n-permutations` i la llavor amb `--seed`.
 
-El JSON generat conté els valors de baseline per direcció.
+El JSON generat conté la mitjana i la desviació estàndard del baseline per
+direcció.
 
 Cada fila dels JSON publicats inclou `repo_url`, calculat amb el helper compartit
 `eval_common.model_urls`.

--- a/llm/comet_baseline.py
+++ b/llm/comet_baseline.py
@@ -1,4 +1,4 @@
-"""Calculate the FLORES source-copy COMET baseline in four directions."""
+"""Calculate the FLORES mismatched-copy COMET baseline in four directions."""
 
 from __future__ import annotations
 
@@ -31,7 +31,7 @@ def save(path: Path, value: dict) -> None:
 
 def result(scores: dict, progress: dict, n_samples: int) -> dict:
     value = {
-        "baseline": "source-copy (mt = src)",
+        "baseline": "mismatched-copy (mt = next ref)",
         "flores_comet_checkpoint": COMET_CHECKPOINT,
         "benchmarks": {"flores": scores},
     }
@@ -71,9 +71,14 @@ def main() -> None:
     for task, (source_key, reference_key) in TASKS.items():
         if task in scores:
             continue
+        references = [row[reference_key] for row in samples]
         examples = [
-            {"src": row[source_key], "ref": row[reference_key], "mt": row[source_key]}
-            for row in samples
+            {
+                "src": row[source_key],
+                "ref": row[reference_key],
+                "mt": references[(index + 1) % args.n_samples],
+            }
+            for index, row in enumerate(samples)
         ]
         state = progress.setdefault(task, {"done": 0, "score_sum": 0.0})
         for start in range(state["done"], args.n_samples, CHUNK_SIZE):
@@ -89,7 +94,10 @@ def main() -> None:
         }
         del progress[task]
         save(args.output, result(scores, progress, args.n_samples))
-        print(f"{task}: source-copy COMET={scores[task]['comet']:.4f}", flush=True)
+        print(
+            f"{task}: mismatched-copy COMET={scores[task]['comet']:.4f}",
+            flush=True,
+        )
 
     save(args.output, result(scores, progress, args.n_samples))
     print(f"Saved baseline to {args.output}", flush=True)

--- a/llm/comet_baseline.py
+++ b/llm/comet_baseline.py
@@ -1,10 +1,12 @@
-"""Calculate the FLORES mismatched-copy COMET baseline in four directions."""
+"""Calculate the FLORES random-mismatch COMET baseline in four directions."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import os
+import random
+from statistics import fmean, stdev
 from pathlib import Path
 
 from comet_config import COMET_CHECKPOINT
@@ -15,7 +17,28 @@ TASKS = {
     "catalan_bench_flores_es-ca": ("sentence_spa_Latn", "sentence_cat_Latn"),
     "catalan_bench_flores_ca-es": ("sentence_cat_Latn", "sentence_spa_Latn"),
 }
-CHUNK_SIZE = 8
+CHUNK_SIZE = 32
+DEFAULT_SEED = 1714
+DEFAULT_PERMUTATIONS = 5
+
+
+def deranged_permutation(size: int, seed: int, index: int) -> list[int]:
+    """Return a deterministic random derangement for mismatched references.
+
+    FLORES devtest is ordered by document. A simple `(i + 1) % n` shift keeps most
+    hypotheses near the original topic, which gives COMET an unrealistically easy
+    mismatch baseline. A random cycle is still deterministic but breaks document
+    adjacency and guarantees that `mt` is never the row's own reference.
+    """
+    if size < 2:
+        raise ValueError("at least two samples are required for a mismatched baseline")
+
+    order = list(range(size))
+    random.Random(f"{seed}:{index}").shuffle(order)
+    permutation = [0] * size
+    for current, next_item in zip(order, order[1:] + order[:1], strict=True):
+        permutation[current] = next_item
+    return permutation
 
 
 def save(path: Path, value: dict) -> None:
@@ -29,15 +52,19 @@ def save(path: Path, value: dict) -> None:
     os.replace(temporary, path)
 
 
-def result(scores: dict, progress: dict, n_samples: int) -> dict:
+def result(
+    scores: dict, progress: dict, n_samples: int, n_permutations: int, seed: int
+) -> dict:
     value = {
-        "baseline": "mismatched-copy (mt = next ref)",
+        "baseline": "random-mismatched reference (fixed-seed derangements)",
         "flores_comet_checkpoint": COMET_CHECKPOINT,
+        "seed": seed,
+        "n_samples": n_samples,
+        "n_permutations": n_permutations,
         "benchmarks": {"flores": scores},
     }
     if progress:
         value["progress"] = progress
-        value["n_samples"] = n_samples
     return value
 
 
@@ -45,13 +72,23 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--n-samples", type=int, default=400)
     parser.add_argument(
+        "--n-permutations",
+        "-k",
+        type=int,
+        default=DEFAULT_PERMUTATIONS,
+        help="Number of fixed-seed random mismatches to average.",
+    )
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument(
         "--output",
         type=Path,
-        default=Path("evals/comet_source_copy_baseline.json"),
+        default=Path("evals/comet_random_mismatch_baseline.json"),
     )
     args = parser.parse_args()
-    if args.n_samples < 1:
-        parser.error("--n-samples must be positive")
+    if args.n_samples < 2:
+        parser.error("--n-samples must be at least 2")
+    if args.n_permutations < 1:
+        parser.error("--n-permutations must be positive")
 
     # FLORES is a legacy dataset script, so datasets requires this opt-in.
     from datasets import load_dataset
@@ -72,34 +109,76 @@ def main() -> None:
         if task in scores:
             continue
         references = [row[reference_key] for row in samples]
-        examples = [
-            {
-                "src": row[source_key],
-                "ref": row[reference_key],
-                "mt": references[(index + 1) % args.n_samples],
-            }
-            for index, row in enumerate(samples)
-        ]
-        state = progress.setdefault(task, {"done": 0, "score_sum": 0.0})
-        for start in range(state["done"], args.n_samples, CHUNK_SIZE):
-            chunk = examples[start : start + CHUNK_SIZE]
-            prediction = comet.predict(chunk, batch_size=CHUNK_SIZE, gpus=0)
-            state["done"] += len(chunk)
-            state["score_sum"] += sum(float(score) for score in prediction.scores)
-            save(args.output, result(scores, progress, args.n_samples))
-            print(f"{task}: {state['done']}/{args.n_samples}", flush=True)
+        state = progress.setdefault(
+            task,
+            {"permutation": 0, "done": 0, "score_sum": 0.0, "permutation_scores": []},
+        )
+        while state["permutation"] < args.n_permutations:
+            permutation_index = state["permutation"]
+            permutation = deranged_permutation(
+                args.n_samples, args.seed, permutation_index
+            )
+            examples = [
+                {
+                    "src": row[source_key],
+                    "ref": row[reference_key],
+                    "mt": references[permutation[index]],
+                }
+                for index, row in enumerate(samples)
+            ]
+            for start in range(state["done"], args.n_samples, CHUNK_SIZE):
+                chunk = examples[start : start + CHUNK_SIZE]
+                prediction = comet.predict(chunk, batch_size=CHUNK_SIZE, gpus=0)
+                state["done"] += len(chunk)
+                state["score_sum"] += sum(float(score) for score in prediction.scores)
+                save(
+                    args.output,
+                    result(
+                        scores, progress, args.n_samples, args.n_permutations, args.seed
+                    ),
+                )
+                print(
+                    f"{task}: permutation {permutation_index + 1}/{args.n_permutations}, "
+                    f"{state['done']}/{args.n_samples}",
+                    flush=True,
+                )
+
+            state["permutation_scores"].append(state["score_sum"] / args.n_samples)
+            state["permutation"] += 1
+            state["done"] = 0
+            state["score_sum"] = 0.0
+            save(
+                args.output,
+                result(
+                    scores, progress, args.n_samples, args.n_permutations, args.seed
+                ),
+            )
+
+        permutation_scores = state["permutation_scores"]
         scores[task] = {
-            "comet": state["score_sum"] / args.n_samples,
+            "comet": fmean(permutation_scores),
+            "comet_stddev": (
+                stdev(permutation_scores) if len(permutation_scores) > 1 else 0.0
+            ),
             "n": args.n_samples,
+            "n_permutations": args.n_permutations,
+            "seed": args.seed,
         }
         del progress[task]
-        save(args.output, result(scores, progress, args.n_samples))
+        save(
+            args.output,
+            result(scores, progress, args.n_samples, args.n_permutations, args.seed),
+        )
         print(
-            f"{task}: mismatched-copy COMET={scores[task]['comet']:.4f}",
+            f"{task}: random-mismatch COMET={scores[task]['comet']:.4f} "
+            f"± {scores[task]['comet_stddev']:.4f}",
             flush=True,
         )
 
-    save(args.output, result(scores, progress, args.n_samples))
+    save(
+        args.output,
+        result(scores, progress, args.n_samples, args.n_permutations, args.seed),
+    )
     print(f"Saved baseline to {args.output}", flush=True)
 
 

--- a/llm/summarize_results.py
+++ b/llm/summarize_results.py
@@ -117,10 +117,10 @@ def load_benchmark_speeds(path: Path) -> dict[str, float]:
 
 
 # Baselines per task for normalization (HF Open LLM Leaderboard v2 approach).
-# FLORES uses the measured source-copy COMET baseline (mt = src), rather than 0.
+# FLORES uses the measured mismatched-copy COMET baseline (mt = next ref).
 COMET_SOURCE_COPY_BASELINES = {
-    "flores_en_ca": fmean((0.6808871791511774, 0.7549228701740504)),
-    "flores_es_ca": fmean((0.8222366382181644, 0.822775568291545)),
+    "flores_en_ca": fmean((0.5303924230486154, 0.5150260711461305)),
+    "flores_es_ca": fmean((0.5241243038326502, 0.514803419932723)),
 }
 
 RANDOM_BASELINES = {

--- a/llm/summarize_results.py
+++ b/llm/summarize_results.py
@@ -117,10 +117,10 @@ def load_benchmark_speeds(path: Path) -> dict[str, float]:
 
 
 # Baselines per task for normalization (HF Open LLM Leaderboard v2 approach).
-# FLORES uses the measured mismatched-copy COMET baseline (mt = next ref).
-COMET_SOURCE_COPY_BASELINES = {
-    "flores_en_ca": fmean((0.5303924230486154, 0.5150260711461305)),
-    "flores_es_ca": fmean((0.5241243038326502, 0.514803419932723)),
+# FLORES uses measured random-mismatch COMET baselines from fixed-seed derangements.
+COMET_RANDOM_MISMATCH_BASELINES = {
+    "flores_en_ca": fmean((0.43233901144564146, 0.40972742018103603)),
+    "flores_es_ca": fmean((0.42619744141399857, 0.4148862131088972)),
 }
 
 RANDOM_BASELINES = {
@@ -128,7 +128,7 @@ RANDOM_BASELINES = {
     "catcola_mcc": 0.0,  # MCC for binary classification: random baseline is 0
     "club_qa_f1": 0.0,  # bounded 0..1, no trivial guesser
     "casum_rougeL": 0.0,  # bounded 0..1
-    **COMET_SOURCE_COPY_BASELINES,
+    **COMET_RANDOM_MISMATCH_BASELINES,
     "ifeval_prompt_strict": 0.0,  # prompt-level strict accuracy, bounded 0..1
 }
 
@@ -155,7 +155,7 @@ def normalize_score(key: str, raw) -> float | None:
     """Normalize a raw metric to 0..1 using HF Open LLM Leaderboard v2 formula.
 
     normalized = (score − baseline) / (1 − baseline), clamped to [0, 1].
-    FLORES COMET uses its measured source-copy baseline.
+    FLORES COMET uses its measured random-mismatch baseline.
     """
     if raw is None:
         return None

--- a/llm/tests/test_comet_baseline.py
+++ b/llm/tests/test_comet_baseline.py
@@ -1,0 +1,18 @@
+from comet_baseline import deranged_permutation
+
+
+def test_deranged_permutation_is_fixed_seed_random_mismatch():
+    first = deranged_permutation(20, seed=1714, index=0)
+    second = deranged_permutation(20, seed=1714, index=0)
+    adjacent_shift = [(index + 1) % 20 for index in range(20)]
+
+    assert first == second
+    assert sorted(first) == list(range(20))
+    assert all(source != target for source, target in enumerate(first))
+    assert first != adjacent_shift
+
+
+def test_deranged_permutation_changes_with_permutation_index():
+    assert deranged_permutation(20, seed=1714, index=0) != deranged_permutation(
+        20, seed=1714, index=1
+    )

--- a/llm/tests/test_summarize_results.py
+++ b/llm/tests/test_summarize_results.py
@@ -1,5 +1,5 @@
 from summarize_results import (
-    COMET_SOURCE_COPY_BASELINES,
+    COMET_RANDOM_MISMATCH_BASELINES,
     extract_metrics,
     normalize_score,
 )
@@ -22,7 +22,7 @@ def test_extract_metrics_uses_comet_for_flores():
     assert metrics["flores_en_ca"] == 0.7
 
 
-def test_comet_uses_the_measured_source_copy_baseline():
-    baseline = COMET_SOURCE_COPY_BASELINES["flores_en_ca"]
+def test_comet_uses_the_measured_random_mismatch_baseline():
+    baseline = COMET_RANDOM_MISMATCH_BASELINES["flores_en_ca"]
     assert normalize_score("flores_en_ca", baseline) == 0.0
     assert normalize_score("flores_en_ca", 0.75) == (0.75 - baseline) / (1 - baseline)


### PR DESCRIPTION
COMET translation score comparison, using the aggregate normalized EN<->CA and ES<->CA score.

| Model | Old COMET | New COMET | Delta |
|---|---:|---:|---:|
| claude-opus-4-7 | 0.4607 | 0.7616 | +0.3010 |
| gpt-5.6 | 0.4524 | 0.7561 | +0.3037 |
| gemini-3.1-pro-preview | 0.4437 | 0.7538 | +0.3101 |
| gpt-5.4-mini | 0.4372 | 0.7496 | +0.3124 |
| bartowski/google_gemma-3-27b-it-GGUF:Q4_K_M | 0.4341 | 0.7475 | +0.3135 |
| bartowski/google_gemma-3-27b-it-GGUF:Q8_0 | 0.4344 | 0.7474 | +0.3130 |
| unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL | 0.4252 | 0.7436 | +0.3184 |
| unsloth/Qwen3.8-27B-GGUF:Q4_K_M | 0.4254 | 0.7431 | +0.3178 |
| bartowski/google_gemma-3-27b-it-GGUF:Q2_K | 0.4242 | 0.7429 | +0.3187 |
| bartowski/EuroLLM-9B-Instruct-GGUF:Q4_K_M | 0.4206 | 0.7414 | +0.3208 |
| bartowski/google_gemma-3-12b-it-GGUF:Q8_0 | 0.4194 | 0.7408 | +0.3214 |
| bartowski/mistralai_Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M | 0.4178 | 0.7398 | +0.3220 |
| mradermacher/salamandra-7b-instruct-2606-GGUF:Q4_K_M | 0.4182 | 0.7396 | +0.3214 |
| bartowski/google_gemma-3-12b-it-GGUF:Q4_K_M | 0.4157 | 0.7390 | +0.3233 |
| bartowski/Qwen_Qwen3.5-9B-GGUF:Q4_K_M | 0.4133 | 0.7374 | +0.3241 |
| gemini-3.7-flash | 0.3949 | 0.7323 | +0.3374 |
| bartowski/google_gemma-4-26B-A4B-it-GGUF:Q4_K_M | 0.3902 | 0.7264 | +0.3361 |
| bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Q4_K_M | 0.3889 | 0.7257 | +0.3368 |
| unsloth/gemma-4-12b-it-GGUF:Q4_K_M | 0.3836 | 0.7243 | +0.3407 |
| bartowski/google_gemma-3-12b-it-GGUF:Q2_K | 0.3839 | 0.7235 | +0.3396 |
| bartowski/Qwen_Qwen3-14B-GGUF:Q4_K_M | 0.3817 | 0.7230 | +0.3413 |
| bartowski/phi-4-GGUF:Q4_K_M | 0.3780 | 0.7200 | +0.3420 |
| bartowski/google_gemma-3-4b-it-GGUF:Q8_0 | 0.3493 | 0.7066 | +0.3574 |
| bartowski/google_gemma-3-4b-it-GGUF:Q4_K_M | 0.3479 | 0.7061 | +0.3582 |
| bartowski/google_gemma-4-E4B-it-GGUF:Q4_K_M | 0.3336 | 0.7004 | +0.3668 |
| bartowski/aya-expanse-8b-GGUF:Q4_K_M | 0.2741 | 0.6719 | +0.3977 |
| bartowski/google_gemma-3-4b-it-GGUF:Q2_K | 0.2144 | 0.6424 | +0.4280 |
| mistralai/Ministral-3-8B-Instruct-2512-GGUF:Q4_K_M | 0.1912 | 0.6312 | +0.4401 |
| mistralai/Ministral-3-14B-Instruct-2512-GGUF:Q4_K_M | 0.1456 | 0.5990 | +0.4534 |

## CLAM impact

The CLAM score changes are real metric-definition changes, not runtime noise. They come from changing the FLORES COMET normalization baseline from source-copy to mismatched-copy. Using the same raw eval result files with different normalization constants produces deterministic and reproducible CLAM deltas.

The rank changes are weaker evidence of model-quality changes. They are small swaps caused by the new normalization weighting translation differently:

| Swap | Branch CLAM gap |
|---|---:|
| gemini-3-7-flash vs gemini-3-1-preview | 0.34 |
| qwen3-14b vs gemma3-27b-q4 | 0.10 |
| qwen3.5-9b vs mistral-small-24b | 0.01 |
| gemma4-e4b-q4 vs eurollm-9b | 0.33 |

So the score increases are real under the new CLAM formula, but the ordering changes are effectively tie-zone movement, especially the `qwen3.5-9b` / `mistral-small-24b` swap. I would not treat those rank changes as meaningful without confidence intervals or repeated runs.
