### PR TITLE
Stop Aya on end-of-turn token

### DIFF
--- a/llm/evals/results_aya_expanse_8b_q4.json
+++ b/llm/evals/results_aya_expanse_8b_q4.json
@@ -4,63 +4,63 @@
   "cloud": false,
   "params_b": 8.0,
   "memory_gb": 4.5,
-  "evaluated_at": "2026-08-25T09:31:03+00:00",
+  "evaluated_at": "2026-08-25T17:27:00+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.5717,
       "n": 400
     },
     "casum": {
-      "rouge1": 0.0344,
-      "rouge2": 0.0208,
-      "rougeL": 0.03,
+      "rouge1": 0.4499,
+      "rouge2": 0.2421,
+      "rougeL": 0.3841,
       "n": 400
     },
     "catcola": {
-      "mcc": null,
-      "accuracy": 0.0,
-      "invalid_rate": 1.0,
-      "coverage": 0.0,
+      "mcc": 0.1504,
+      "accuracy": 0.325,
+      "invalid_rate": 0.59,
+      "coverage": 0.41,
       "n": 400,
-      "n_valid": 0,
-      "n_invalid": 400
+      "n_valid": 164,
+      "n_invalid": 236
     },
     "club_qa": {
-      "exact_match_approx": 0.0,
-      "token_f1": 0.0,
+      "exact_match_approx": 0.79,
+      "token_f1": 0.6897,
       "n": 400
     },
     "flores": {
       "catalan_bench_flores_en-ca": {
         "alias": "catalan_bench_flores_en-ca",
         "n": 400,
-        "comet": 0.7151574982702732
+        "comet": 0.8175477482378483
       },
       "catalan_bench_flores_ca-en": {
         "alias": "catalan_bench_flores_ca-en",
         "n": 400,
-        "comet": 0.8190359150618315
+        "comet": 0.8768953168392182
       },
       "catalan_bench_flores_es-ca": {
         "alias": "catalan_bench_flores_es-ca",
         "n": 400,
-        "comet": 0.28758019089698794
+        "comet": 0.8193893155455589
       },
       "catalan_bench_flores_ca-es": {
         "alias": "catalan_bench_flores_ca-es",
         "n": 400,
-        "comet": 0.1743798502162099
+        "comet": 0.8575041511654854
       }
     },
     "ifeval": {
       "alias": "ifeval_ca",
-      "prompt_level_strict_acc,none": 0.1725,
-      "prompt_level_strict_acc_stderr,none": 0.018914379699014616,
-      "inst_level_strict_acc,none": 0.2778702163061564,
+      "prompt_level_strict_acc,none": 0.3725,
+      "prompt_level_strict_acc_stderr,none": 0.024203800008203106,
+      "inst_level_strict_acc,none": 0.49916805324459235,
       "inst_level_strict_acc_stderr,none": "N/A",
-      "prompt_level_loose_acc,none": 0.22,
-      "prompt_level_loose_acc_stderr,none": 0.020738254217024268,
-      "inst_level_loose_acc,none": 0.33777038269550747,
+      "prompt_level_loose_acc,none": 0.435,
+      "prompt_level_loose_acc_stderr,none": 0.024818892876375905,
+      "inst_level_loose_acc,none": 0.5590682196339434,
       "inst_level_loose_acc_stderr,none": "N/A",
       "n": 400
     }

--- a/llm/evals/results_aya_expanse_8b_q4.json
+++ b/llm/evals/results_aya_expanse_8b_q4.json
@@ -4,65 +4,65 @@
   "cloud": false,
   "params_b": 8.0,
   "memory_gb": 4.5,
-  "evaluated_at": "2026-08-16T17:38:21+00:00",
+  "evaluated_at": "2026-08-25T09:31:03+00:00",
   "benchmarks": {
     "sts_ca": {
-      "pearson": 0.5728,
+      "pearson": 0.5717,
       "n": 400
     },
     "casum": {
-      "rouge1": 0.4008,
-      "rouge2": 0.2123,
-      "rougeL": 0.341,
+      "rouge1": 0.0344,
+      "rouge2": 0.0208,
+      "rougeL": 0.03,
       "n": 400
     },
     "catcola": {
-      "mcc": 0.0783,
-      "accuracy": 0.3275,
-      "invalid_rate": 0.585,
-      "coverage": 0.415,
+      "mcc": null,
+      "accuracy": 0.0,
+      "invalid_rate": 1.0,
+      "coverage": 0.0,
       "n": 400,
-      "n_valid": 166,
-      "n_invalid": 234
+      "n_valid": 0,
+      "n_invalid": 400
     },
     "club_qa": {
-      "exact_match_approx": 0.79,
-      "token_f1": 0.6936,
+      "exact_match_approx": 0.0,
+      "token_f1": 0.0,
       "n": 400
     },
     "flores": {
       "catalan_bench_flores_en-ca": {
         "alias": "catalan_bench_flores_en-ca",
         "n": 400,
-        "comet": 0.649142465814948
+        "comet": 0.7151574982702732
       },
       "catalan_bench_flores_ca-en": {
         "alias": "catalan_bench_flores_ca-en",
         "n": 400,
-        "comet": 0.7039690905809403
+        "comet": 0.8190359150618315
       },
       "catalan_bench_flores_es-ca": {
         "alias": "catalan_bench_flores_es-ca",
         "n": 400,
-        "comet": 0.6574711172282696
+        "comet": 0.28758019089698794
       },
       "catalan_bench_flores_ca-es": {
         "alias": "catalan_bench_flores_ca-es",
         "n": 400,
-        "comet": 0.683432533442974
+        "comet": 0.1743798502162099
       }
     },
     "ifeval": {
       "alias": "ifeval_ca",
-      "n": 400,
-      "prompt_level_strict_acc,none": 0.3275,
-      "prompt_level_strict_acc_stderr,none": 0.02349445356612767,
-      "inst_level_strict_acc,none": 0.4459234608985025,
+      "prompt_level_strict_acc,none": 0.1725,
+      "prompt_level_strict_acc_stderr,none": 0.018914379699014616,
+      "inst_level_strict_acc,none": 0.2778702163061564,
       "inst_level_strict_acc_stderr,none": "N/A",
-      "prompt_level_loose_acc,none": 0.42,
-      "prompt_level_loose_acc_stderr,none": 0.02470883072485368,
-      "inst_level_loose_acc,none": 0.5257903494176372,
-      "inst_level_loose_acc_stderr,none": "N/A"
+      "prompt_level_loose_acc,none": 0.22,
+      "prompt_level_loose_acc_stderr,none": 0.020738254217024268,
+      "inst_level_loose_acc,none": 0.33777038269550747,
+      "inst_level_loose_acc_stderr,none": "N/A",
+      "n": 400
     }
   },
   "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"

--- a/llm/llamaserver.py
+++ b/llm/llamaserver.py
@@ -7,6 +7,7 @@ from inference import call_with_retries, chat_completion_params, inference_param
 
 _MUSE_USER_TEMPLATE = Path(__file__).with_name("templates") / "muse_glimmer_user.jinja"
 _MUSE_BOS_TOKEN = "<|begin_of_text|>"
+_AYA_END_OF_TURN_TOKEN = "<|END_OF_TURN_TOKEN|>"
 
 
 def _hf_tokenizer_from_gguf(model_spec: str) -> str:
@@ -105,6 +106,8 @@ class LlamaServerModel:
             "messages": messages,
             **params,
         }
+        if "aya-expanse" in self.model_spec.lower():
+            payload_data["stop"] = [_AYA_END_OF_TURN_TOKEN]
         if self.request_model:
             payload_data["model"] = self.request_model
         return self._post_json("/chat/completions", payload_data)

--- a/llm/model.py
+++ b/llm/model.py
@@ -665,6 +665,7 @@ def run_flores(
             f"model={model_name},"
             f"base_url={base_url}/chat/completions,"
             f"num_concurrent=1,max_retries=3,tokenized_requests=False"
+            f"{',eos_string=<|END_OF_TURN_TOKEN|>' if 'aya-expanse' in model_name.lower() else ''}"
         )
     else:
         lm_model = "hf"
@@ -805,6 +806,7 @@ def run_ifeval(
             f"model={model_name},"
             f"base_url={base_url}/chat/completions,"
             f"num_concurrent=1,max_retries=3,timeout=120,tokenized_requests=False"
+            f"{',eos_string=<|END_OF_TURN_TOKEN|>' if 'aya-expanse' in model_name.lower() else ''}"
         )
     else:
         lm_model = "hf"


### PR DESCRIPTION
Adds Aya-specific eos_string for local lm-eval harness calls so generated outputs stop at <|END_OF_TURN_TOKEN|>. This is gated to model names containing aya-expanse and does not affect other models.