### PR TITLE
Use proper Catalan accents in CatCoLA prompt

### DIFF
--- a/llm/evals/results_aya_expanse_8b_q4.json
+++ b/llm/evals/results_aya_expanse_8b_q4.json
@@ -2,9 +2,9 @@
   "model": "bartowski/aya-expanse-8b-GGUF:Q4_K_M",
   "display_name": "aya-expanse-8b",
   "cloud": false,
-  "params_b": 8.0,
+  "params_b": 8,
   "memory_gb": 4.5,
-  "evaluated_at": "2026-08-25T17:27:00+00:00",
+  "evaluated_at": "2026-08-27T09:11:18+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.5717,
@@ -17,13 +17,13 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1504,
-      "accuracy": 0.325,
-      "invalid_rate": 0.59,
-      "coverage": 0.41,
+      "mcc": 0.1614,
+      "accuracy": 0.745,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
-      "n_valid": 164,
-      "n_invalid": 236
+      "n_valid": 400,
+      "n_invalid": 0
     },
     "club_qa": {
       "exact_match_approx": 0.79,

--- a/llm/evals/results_eurollm_9b_q4.json
+++ b/llm/evals/results_eurollm_9b_q4.json
@@ -2,9 +2,9 @@
   "model": "bartowski/EuroLLM-9B-Instruct-GGUF:Q4_K_M",
   "display_name": "eurollm-9b",
   "cloud": false,
-  "params_b": 9.0,
+  "params_b": 9,
   "memory_gb": 5.1,
-  "evaluated_at": "2026-08-16T17:38:21+00:00",
+  "evaluated_at": "2026-08-27T08:23:22+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.3753,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.2861,
-      "accuracy": 0.725,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3112,
+      "accuracy": 0.7025,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemini_3_1_preview.json
+++ b/llm/evals/results_gemini_3_1_preview.json
@@ -4,7 +4,7 @@
   "cloud": true,
   "params_b": null,
   "memory_gb": null,
-  "evaluated_at": "2026-08-22T18:09:25+00:00",
+  "evaluated_at": "2026-08-27T10:16:44+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.8236,
@@ -19,8 +19,8 @@
     "catcola": {
       "mcc": 0.5298,
       "accuracy": 0.835,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemini_3_7_flash.json
+++ b/llm/evals/results_gemini_3_7_flash.json
@@ -4,7 +4,7 @@
   "cloud": true,
   "params_b": null,
   "memory_gb": null,
-  "evaluated_at": "2026-08-22T16:56:45+00:00",
+  "evaluated_at": "2026-08-27T11:14:01+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.8361,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.5046,
-      "accuracy": 0.8225,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.5185,
+      "accuracy": 0.825,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_12b.json
+++ b/llm/evals/results_gemma3_12b.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-12b-it-GGUF:Q8_0",
   "display_name": "gemma3-12b-q8",
   "cloud": false,
-  "params_b": 12.0,
+  "params_b": 12,
   "memory_gb": 12.8,
-  "evaluated_at": "2026-08-24T22:24:40+00:00",
+  "evaluated_at": "2026-08-27T08:36:45+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7153,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3605,
-      "accuracy": 0.79,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3897,
+      "accuracy": 0.785,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_12b_q2.json
+++ b/llm/evals/results_gemma3_12b_q2.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-12b-it-GGUF:Q2_K",
   "display_name": "gemma3-12b-q2",
   "cloud": false,
-  "params_b": 12.0,
+  "params_b": 12,
   "memory_gb": 12.8,
-  "evaluated_at": "2026-08-24T14:12:29+00:00",
+  "evaluated_at": "2026-08-27T08:32:52+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6444,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.4066,
-      "accuracy": 0.7825,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3706,
+      "accuracy": 0.7425,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_12b_q4.json
+++ b/llm/evals/results_gemma3_12b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-12b-it-GGUF:Q4_K_M",
   "display_name": "gemma3-12b",
   "cloud": false,
-  "params_b": 12.0,
+  "params_b": 12,
   "memory_gb": 6.8,
-  "evaluated_at": "2026-08-24T18:28:43+00:00",
+  "evaluated_at": "2026-08-27T08:35:00+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6969,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3505,
-      "accuracy": 0.7875,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3608,
+      "accuracy": 0.775,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_27b.json
+++ b/llm/evals/results_gemma3_27b.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-27b-it-GGUF:Q8_0",
   "display_name": "gemma3-27b-q8",
   "cloud": false,
-  "params_b": 27.0,
+  "params_b": 27,
   "memory_gb": 28.7,
-  "evaluated_at": "2026-08-25T20:38:22+00:00",
+  "evaluated_at": "2026-08-27T08:47:58+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7558,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3902,
-      "accuracy": 0.78,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3875,
+      "accuracy": 0.79,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_27b_q2.json
+++ b/llm/evals/results_gemma3_27b_q2.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-27b-it-GGUF:Q2_K",
   "display_name": "gemma3-27b-q2",
   "cloud": false,
-  "params_b": 27.0,
+  "params_b": 27,
   "memory_gb": 28.7,
-  "evaluated_at": "2026-08-25T04:01:43+00:00",
+  "evaluated_at": "2026-08-27T08:39:08+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7095,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.338,
-      "accuracy": 0.6375,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.307,
+      "accuracy": 0.71,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_27b_q4.json
+++ b/llm/evals/results_gemma3_27b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-27b-it-GGUF:Q4_K_M",
   "display_name": "gemma3-27b",
   "cloud": false,
-  "params_b": 27.0,
+  "params_b": 27,
   "memory_gb": 15.2,
-  "evaluated_at": "2026-08-25T12:21:37+00:00",
+  "evaluated_at": "2026-08-27T08:43:41+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7599,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.331,
-      "accuracy": 0.7625,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3654,
+      "accuracy": 0.7875,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_4b_q2.json
+++ b/llm/evals/results_gemma3_4b_q2.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-4b-it-GGUF:Q2_K",
   "display_name": "gemma3-4b-q2",
   "cloud": false,
-  "params_b": 4.0,
+  "params_b": 4,
   "memory_gb": 4.2,
-  "evaluated_at": "2026-08-24T08:26:42+00:00",
+  "evaluated_at": "2026-08-27T08:30:13+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.3563,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1972,
-      "accuracy": 0.6325,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2407,
+      "accuracy": 0.6275,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_4b_q4.json
+++ b/llm/evals/results_gemma3_4b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/gemma-3-4b-it-GGUF:Q4_K_M",
   "display_name": "gemma3-4b",
   "cloud": false,
-  "params_b": 4.0,
+  "params_b": 4,
   "memory_gb": 2.2,
-  "evaluated_at": "2026-08-24T10:21:09+00:00",
+  "evaluated_at": "2026-08-27T08:31:06+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.442,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.2681,
-      "accuracy": 0.69,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3246,
+      "accuracy": 0.725,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_gemma3_4b_q8.json
+++ b/llm/evals/results_gemma3_4b_q8.json
@@ -2,7 +2,7 @@
   "model": "bartowski/google_gemma-3-4b-it-GGUF:Q8_0",
   "display_name": "gemma3-4b",
   "cloud": false,
-  "params_b": 4.0,
+  "params_b": 4,
   "memory_gb": 4.2,
   "benchmarks": {
     "sts_ca": {
@@ -16,10 +16,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.2486,
-      "accuracy": 0.66,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3119,
+      "accuracy": 0.71,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0
@@ -35,8 +35,8 @@
         "n": 400,
         "acc,none": 0.25,
         "acc_stderr,none": 0.021677749238103,
-        "mcc,none": 0.0,
-        "mcc_stderr,none": 0.0
+        "mcc,none": 0,
+        "mcc_stderr,none": 0
       },
       "wnli_ca": {
         "alias": "wnli_ca",
@@ -87,5 +87,6 @@
     }
   },
   "quantization": "q8",
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T08:31:51+00:00"
 }

--- a/llm/evals/results_gemma4_12b_q4.json
+++ b/llm/evals/results_gemma4_12b_q4.json
@@ -2,7 +2,7 @@
   "model": "unsloth/gemma-4-12b-it-GGUF:Q4_K_M",
   "display_name": "gemma4-12b-q4",
   "cloud": false,
-  "params_b": 12.0,
+  "params_b": 12,
   "memory_gb": 6.8,
   "benchmarks": {
     "sts_ca": {
@@ -16,9 +16,13 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.2657,
-      "accuracy": 0.5475,
-      "n": 400
+      "mcc": 0.2764,
+      "accuracy": 0.665,
+      "invalid_rate": 0,
+      "coverage": 1,
+      "n": 400,
+      "n_valid": 400,
+      "n_invalid": 0
     },
     "club_qa": {
       "exact_match_approx": 0.8225,
@@ -31,8 +35,8 @@
         "n": 400,
         "acc,none": 0.25,
         "acc_stderr,none": 0.021677749238103,
-        "mcc,none": 0.0,
-        "mcc_stderr,none": 0.0
+        "mcc,none": 0,
+        "mcc_stderr,none": 0
       },
       "wnli_ca": {
         "alias": "wnli_ca",
@@ -83,5 +87,6 @@
     }
   },
   "quantization": "q4",
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T09:14:41+00:00"
 }

--- a/llm/evals/results_gemma4_26b_q4.json
+++ b/llm/evals/results_gemma4_26b_q4.json
@@ -1,7 +1,7 @@
 {
   "model": "bartowski/google_gemma-4-26B-A4B-it-GGUF:Q4_K_M",
   "display_name": "gemma4-26b-q4",
-  "params_b": 26.0,
+  "params_b": 26,
   "memory_gb": 14.6,
   "benchmarks": {
     "sts_ca": {
@@ -15,9 +15,13 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1829,
-      "accuracy": 0.5525,
-      "n": 400
+      "mcc": 0.2839,
+      "accuracy": 0.6975,
+      "invalid_rate": 0,
+      "coverage": 1,
+      "n": 400,
+      "n_valid": 400,
+      "n_invalid": 0
     },
     "club_qa": {
       "exact_match_approx": 0.78,
@@ -30,8 +34,8 @@
         "n": 400,
         "acc,none": 0.25,
         "acc_stderr,none": 0.021677749238103,
-        "mcc,none": 0.0,
-        "mcc_stderr,none": 0.0
+        "mcc,none": 0,
+        "mcc_stderr,none": 0
       },
       "wnli_ca": {
         "alias": "wnli_ca",
@@ -82,5 +86,6 @@
     }
   },
   "quantization": "q4",
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T09:17:21+00:00"
 }

--- a/llm/evals/results_gemma4_e4b_q4.json
+++ b/llm/evals/results_gemma4_e4b_q4.json
@@ -2,7 +2,7 @@
   "model": "bartowski/google_gemma-4-E4B-it-GGUF:Q4_K_M",
   "display_name": "gemma4-e4b-q4",
   "cloud": false,
-  "params_b": 4.0,
+  "params_b": 4,
   "memory_gb": 2.2,
   "benchmarks": {
     "sts_ca": {
@@ -16,9 +16,13 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1536,
-      "accuracy": 0.4925,
-      "n": 400
+      "mcc": 0.2583,
+      "accuracy": 0.6375,
+      "invalid_rate": 0,
+      "coverage": 1,
+      "n": 400,
+      "n_valid": 400,
+      "n_invalid": 0
     },
     "club_qa": {
       "exact_match_approx": 0.815,
@@ -31,8 +35,8 @@
         "n": 400,
         "acc,none": 0.25,
         "acc_stderr,none": 0.021677749238103,
-        "mcc,none": 0.0,
-        "mcc_stderr,none": 0.0
+        "mcc,none": 0,
+        "mcc_stderr,none": 0
       },
       "wnli_ca": {
         "alias": "wnli_ca",
@@ -82,5 +86,6 @@
       "inst_level_loose_acc_stderr,none": "N/A"
     }
   },
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T09:16:25+00:00"
 }

--- a/llm/evals/results_gpt_5_4_mini.json
+++ b/llm/evals/results_gpt_5_4_mini.json
@@ -16,10 +16,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.4797,
-      "accuracy": 0.775,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.4363,
+      "accuracy": 0.79,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0
@@ -68,5 +68,6 @@
     }
   },
   "quantization": "",
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T08:46:57+00:00"
 }

--- a/llm/evals/results_gpt_5_6.json
+++ b/llm/evals/results_gpt_5_6.json
@@ -16,10 +16,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.5423,
-      "accuracy": 0.8375,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.5325,
+      "accuracy": 0.8275,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0
@@ -75,5 +75,6 @@
     "failed_generations": 0
   },
   "quantization": "",
-  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da"
+  "flores_comet_checkpoint": "Unbabel/wmt22-comet-da",
+  "evaluated_at": "2026-08-27T09:26:00+00:00"
 }

--- a/llm/evals/results_llama3.1_8b_q4.json
+++ b/llm/evals/results_llama3.1_8b_q4.json
@@ -2,9 +2,9 @@
   "model": "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF:Q4_K_M",
   "display_name": "llama3.1-8b",
   "cloud": false,
-  "params_b": 8.0,
+  "params_b": 8,
   "memory_gb": 4.5,
-  "evaluated_at": "2026-08-16T14:15:31+00:00",
+  "evaluated_at": "2026-08-27T09:10:19+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.4506,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1984,
-      "accuracy": 0.425,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2357,
+      "accuracy": 0.6925,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_ministral3_14b_q4.json
+++ b/llm/evals/results_ministral3_14b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Ministral-3-14B-Instruct-2512-GGUF:Q4_K_M",
   "display_name": "ministral3-14b",
   "cloud": false,
-  "params_b": 14.0,
+  "params_b": 14,
   "memory_gb": 7.9,
-  "evaluated_at": "2026-08-26T16:18:38+00:00",
+  "evaluated_at": "2026-08-27T08:56:33+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6456,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1502,
-      "accuracy": 0.405,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2744,
+      "accuracy": 0.6275,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_ministral3_8b_q4.json
+++ b/llm/evals/results_ministral3_8b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Ministral-3-8B-Instruct-2512-GGUF:Q4_K_M",
   "display_name": "ministral3-8b",
   "cloud": false,
-  "params_b": 8.0,
+  "params_b": 8,
   "memory_gb": 4.5,
-  "evaluated_at": "2026-08-26T13:23:55+00:00",
+  "evaluated_at": "2026-08-27T08:55:41+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.5913,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.1858,
-      "accuracy": 0.3775,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2806,
+      "accuracy": 0.6375,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_mistral_small_24b_q4.json
+++ b/llm/evals/results_mistral_small_24b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Mistral-Small-3.2-24B-Instruct-2506-GGUF:Q4_K_M",
   "display_name": "mistral-small-24b",
   "cloud": false,
-  "params_b": 24.0,
+  "params_b": 24,
   "memory_gb": 13.5,
-  "evaluated_at": "2026-08-26T08:52:50+00:00",
+  "evaluated_at": "2026-08-27T08:53:31+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6966,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3911,
-      "accuracy": 0.7275,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.4248,
+      "accuracy": 0.7625,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_muse_glimmer_30b_q4.json
+++ b/llm/evals/results_muse_glimmer_30b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Muse-Glimmer-30B-GGUF:UD-Q4_K_XL",
   "display_name": "muse-glimmer-30b",
   "cloud": false,
-  "params_b": 30.0,
+  "params_b": 30,
   "memory_gb": 16.9,
-  "evaluated_at": "2026-08-18T07:37:28+00:00",
+  "evaluated_at": "2026-08-27T09:06:23+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7622,
@@ -17,13 +17,13 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.418,
-      "accuracy": 0.6325,
-      "invalid_rate": 0.1675,
-      "coverage": 0.8325,
+      "mcc": 0.3062,
+      "accuracy": 0.5075,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
-      "n_valid": 333,
-      "n_invalid": 67
+      "n_valid": 400,
+      "n_invalid": 0
     },
     "club_qa": {
       "exact_match_approx": 0.8225,

--- a/llm/evals/results_phi4_q4.json
+++ b/llm/evals/results_phi4_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/phi-4-GGUF:Q4_K_M",
   "display_name": "phi-4-14b",
   "cloud": false,
-  "params_b": 14.0,
+  "params_b": 14,
   "memory_gb": 7.9,
-  "evaluated_at": "2026-08-26T23:50:17+00:00",
+  "evaluated_at": "2026-08-27T08:59:14+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6299,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.2752,
-      "accuracy": 0.73,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2957,
+      "accuracy": 0.77,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_qwen3.5_9b_q4.json
+++ b/llm/evals/results_qwen3.5_9b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Qwen3.5-9B-GGUF:Q4_K_M",
   "display_name": "qwen3.5-9b",
   "cloud": false,
-  "params_b": 9.0,
+  "params_b": 9,
   "memory_gb": 5.1,
-  "evaluated_at": "2026-08-27T03:58:01+00:00",
+  "evaluated_at": "2026-08-27T09:00:49+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6998,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3827,
-      "accuracy": 0.78,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.2511,
+      "accuracy": 0.7725,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_qwen3.8_27b.json
+++ b/llm/evals/results_qwen3.8_27b.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Qwen3.8-27B-GGUF:Q4_K_M",
   "display_name": "qwen3.8-27b",
   "cloud": false,
-  "params_b": 27.0,
+  "params_b": 27,
   "memory_gb": 15.2,
-  "evaluated_at": "2026-08-17T12:08:20+00:00",
+  "evaluated_at": "2026-08-27T09:02:12+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.7616,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3874,
-      "accuracy": 0.62,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.412,
+      "accuracy": 0.6375,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_qwen3_14b_q4.json
+++ b/llm/evals/results_qwen3_14b_q4.json
@@ -2,9 +2,9 @@
   "model": "unsloth/Qwen3-14B-GGUF:Q4_K_M",
   "display_name": "qwen3-14b",
   "cloud": false,
-  "params_b": 14.0,
+  "params_b": 14,
   "memory_gb": 7.9,
-  "evaluated_at": "2026-08-26T20:27:26+00:00",
+  "evaluated_at": "2026-08-27T08:57:49+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.6811,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.3699,
-      "accuracy": 0.745,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0.3653,
+      "accuracy": 0.705,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/evals/results_salamandra_7b_q4.json
+++ b/llm/evals/results_salamandra_7b_q4.json
@@ -2,9 +2,9 @@
   "model": "mradermacher/salamandra-7b-instruct-2606-GGUF:Q4_K_M",
   "display_name": "salamandra-7b",
   "cloud": false,
-  "params_b": 7.0,
+  "params_b": 7,
   "memory_gb": 3.9,
-  "evaluated_at": "2026-08-16T21:15:18+00:00",
+  "evaluated_at": "2026-08-27T09:14:01+00:00",
   "benchmarks": {
     "sts_ca": {
       "pearson": 0.2855,
@@ -17,10 +17,10 @@
       "n": 400
     },
     "catcola": {
-      "mcc": 0.0502,
-      "accuracy": 0.2575,
-      "invalid_rate": 0.0,
-      "coverage": 1.0,
+      "mcc": 0,
+      "accuracy": 0.25,
+      "invalid_rate": 0,
+      "coverage": 1,
       "n": 400,
       "n_valid": 400,
       "n_invalid": 0

--- a/llm/model.py
+++ b/llm/model.py
@@ -271,8 +271,8 @@ def run_catcola(model, n_samples: int = 200) -> dict:
         label = item["Label"]  # 0 = unacceptable, 1 = acceptable
 
         prompt = (
-            "La seguent frase en catala es gramaticalment correcta? "
-            "Respon nomes amb 'si' o 'no'.\n\n"
+            "La següent frase en català és gramaticalment correcta? "
+            "Respon només amb 'sí' o 'no'.\n\n"
             f"Frase: {sentence}\nResposta:"
         )
         answer = model.generate(prompt, max_new_tokens=16)


### PR DESCRIPTION
## CatCoLA rerun — accented prompt

Each completed evaluation uses all 400 CatCoLA validation samples. Baseline is the result recorded before this prompt change; “New” uses the accented Catalan prompt in this PR.

| Model | Baseline MCC | New MCC | Δ |
|---|---:|---:|---:|
| gemma3-4b-q2 | 0.1972 | 0.2407 | +0.0435 |
| gemma3-4b | 0.2681 | 0.3246 | +0.0565 |
| gemma3-4b-q8 | 0.2486 | 0.3119 | +0.0633 |
| gemma3-12b-q2 | 0.4066 | 0.3706 | -0.0360 |
| gemma3-12b | 0.3505 | 0.3608 | +0.0103 |
| gemma3-12b-q8 | 0.3605 | 0.3897 | +0.0292 |
| gemma3-27b-q2 | 0.3380 | 0.3070 | -0.0310 |
| gemma3-27b | 0.3310 | 0.3654 | +0.0344 |
| gemma3-27b-q8 | 0.3902 | 0.3875 | -0.0027 |
| mistral-small-24b | 0.3911 | 0.4248 | +0.0337 |
| ministral3-8b | 0.1858 | 0.2806 | +0.0948 |
| ministral3-14b | 0.1502 | 0.2744 | +0.1242 |
| qwen3-14b | 0.3699 | 0.3653 | -0.0046 |
| phi-4-14b | 0.2752 | 0.2957 | +0.0205 |
| qwen3.5-9b | 0.3827 | 0.2511 | -0.1316 |
| qwen3.8-27b | 0.3874 | 0.4120 | +0.0246 |
| muse-glimmer-30b | 0.4180 | 0.3062 | -0.1118 |
| llama3.1-8b | 0.1984 | 0.2357 | +0.0373 |
| aya-expanse-8b | 0.1504 | 0.1614 | +0.0110 |
| eurollm-9b | 0.2861 | 0.3112 | +0.0251 |
| salamandra-7b | 0.0502 | 0.0000 | -0.0502 |
| gemma4-12b | 0.2657 | 0.2764 | +0.0107 |
| gemma4-e4b | 0.1536 | 0.2583 | +0.1047 |
| gemma4-26b | 0.1829 | 0.2839 | +0.1010 |
| gemini-3-1-preview | 0.5298 | 0.5298 | +0.0000 |
| gemini-3-7-flash | 0.5046 | 0.5185 | +0.0139 |
| gpt-5.4-mini | 0.4797 | 0.4363 | -0.0434 |
| gpt-5.6 | 0.5423 | 0.5325 | -0.0098 |

All completed runs had 0% invalid responses. Claude Opus is not included because its required Bedrock credential was unavailable to the evaluation runner.
